### PR TITLE
Added memoization benchmark, LCS problem

### DIFF
--- a/testcases/lazy-datastructures/memoization/LongestCommonSubsequence.scala
+++ b/testcases/lazy-datastructures/memoization/LongestCommonSubsequence.scala
@@ -1,0 +1,27 @@
+import leon._
+import mem._
+import lang._
+import annotation._
+import instrumentation._
+//import leon.invariant._
+
+object LCS {
+  def max(a: BigInt, b: BigInt): BigInt = {
+    require(a >= 0 && b >= 0)
+    if (a > b) a else b
+  }
+
+  @memoize
+  def lcs(m: BigInt, n: BigInt, X: String, Y: String): BigInt = {
+    require(n >= 0 && m >= 0)
+    if(m == 0 || n == 0)
+      BigInt(0)
+    else if(X(m.toInt - 1) == Y(n.toInt - 1))
+      1 + lcs(m - 1, n - 1, X, Y)
+    else
+      max(lcs(m - 1, n, X, Y), lcs(m, n - 1, X, Y))
+  } ensuring(_ =>
+    (m == 0 || n == 0 || (lcs(m - 1, n - 1, X, Y).isCached &&
+      lcs(m - 1, n, X, Y).isCached && lcs(m, n - 1, X, Y).isCached)) &&
+      time <= ?*m*n + ?*m + ?*n + ?)
+}


### PR DESCRIPTION
A shot at writing benchmarks

Following queries:
1) In the `lcs` functions, I couldn't access the string elements using `m` or `n` as they were BigInt. Needed to explicitly convert them to Int. Basically

```
X(m - 1) == Y(n - 1)
```

didn't work and hence had to write

```
X(m.toInt - 1) == Y(n.toInt - 1)
```

2) The complexity is O(m*n), I left `?` at the `time` check at `ensuring`. What should I do of that?
